### PR TITLE
Support Arbitrary Matrix Shapes

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -28,6 +28,10 @@ generate_testvectors:
     - !reference [.setup_test, script]
     - python testGenerator.py -H 1 -S 64 -E 64 -P 64
     - python testGenerator.py -H 1 -S 128 -E 192 -P 256
+    - python testGenerator.py -H 1 -S 1 -E 2 -P 3 --no-bias
+    - python testGenerator.py -H 1 -S 63 -E 62 -P 61 --no-bias
+    - python testGenerator.py -H 1 -S 65 -E 130 -P 195 --no-bias
+    - python testGenerator.py -H 1 -S 127 -E 190 -P 253 --no-bias
   artifacts:
     paths:
       - simvectors
@@ -48,6 +52,29 @@ run_sim:
   script:
     - make bender
     - make sim VSIM_FLAGS=-c s=$S e=$E p=$P bias=1
+    - ./modelsim/return_status.sh modelsim/build/transcript $S $E ita_tb
+
+run_sim_padding:
+  stage: sim
+  needs:
+    - generate_testvectors
+  parallel:
+    matrix:
+    - S: 1
+      E: 2
+      P: 3
+    - S: 63
+      E: 62
+      P: 61
+    - S: 65
+      E: 130
+      P: 195
+    - S: 127
+      E: 190
+      P: 253
+  script:
+    - make bender
+    - make sim VSIM_FLAGS=-c s=$S e=$E p=$P bias=0
     - ./modelsim/return_status.sh modelsim/build/transcript $S $E ita_tb
 
 run_hwpe_sim:

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -17,6 +17,7 @@
                 "-S${input:seq_len}",
                 "-E${input:emb_len}",
                 "-P${input:prj_len}",
+                "--no-bias"
             ],
         }
     ],

--- a/PyITA/ITA.py
+++ b/PyITA/ITA.py
@@ -60,9 +60,9 @@ class Transformer:
 
         self._init_paths(path)
 
-        self.S_ITA = max(64, S)
-        self.P_ITA = max(64, P)
-        self.E_ITA = max(64, E)
+        self.S_ITA = ((S - 1) // self.ITA_M + 1) * self.ITA_M
+        self.P_ITA = ((P - 1) // self.ITA_M + 1) * self.ITA_M
+        self.E_ITA = ((E - 1) // self.ITA_M + 1) * self.ITA_M
         self.H_ITA = 4
         self.split = self.ITA_M // self.ITA_N
 
@@ -97,9 +97,9 @@ class Transformer:
         assert (np.all(K == V))
 
         # WIESEP: Current restrictions for ITA
-        assert (self.S % self.ITA_M == 0), "Sequence length must be divisible by ITA_M"
-        assert (self.P % self.ITA_M == 0), "Projection space must be divisible by ITA_M"
-        assert (self.E % self.ITA_M == 0), "Embedding size must be divisible by ITA_M"
+        # assert (self.S % self.ITA_M == 0), "Sequence length must be divisible by ITA_M"
+        # assert (self.P % self.ITA_M == 0), "Projection space must be divisible by ITA_M"
+        # assert (self.E % self.ITA_M == 0), "Embedding size must be divisible by ITA_M"
 
         assert (
             self.E <= 512
@@ -147,7 +147,8 @@ class Transformer:
         else:
             self.Bq_in = np.zeros((self.H, self.P), dtype = np.int8)
         self.Bq = np.pad(self.Bq_in, ((0, 0), (0, self.P_ITA - self.P)))
-        self.Bq_broadcast = np.reshape(np.repeat(self.Bq, self.S, axis = 0), (self.H, self.S, self.P))
+        self.Bq_broadcast = np.reshape(np.repeat(self.Bq, self.S, axis = 0), (self.H, self.S, self.P_ITA))
+        self.Bq_broadcast = np.pad(self.Bq_broadcast, ((0, 0), (0, self.S_ITA - self.S), (0, 0)))
 
         if self.bias:
             self.Bk_in = random_shuffled_tensor(
@@ -155,7 +156,8 @@ class Transformer:
         else:
             self.Bk_in = np.zeros((self.H, self.P), dtype = np.int8)
         self.Bk = np.pad(self.Bk_in, ((0, 0), (0, self.P_ITA - self.P)))
-        self.Bk_broadcast = np.reshape(np.repeat(self.Bk, self.S, axis = 0), (self.H, self.S, self.P))
+        self.Bk_broadcast = np.reshape(np.repeat(self.Bk, self.S, axis = 0), (self.H, self.S, self.P_ITA))
+        self.Bk_broadcast = np.pad(self.Bk_broadcast, ((0, 0), (0, self.S_ITA - self.S), (0, 0)))
 
         if self.bias:
             self.Bv_in = random_shuffled_tensor(
@@ -163,7 +165,8 @@ class Transformer:
         else:
             self.Bv_in = np.zeros((self.H, self.P), dtype = np.int8)
         self.Bv = np.pad(self.Bv_in, ((0, 0), (0, self.P_ITA - self.P)))
-        self.Bv_broadcast = np.reshape(np.repeat(self.Bv, self.S, axis = 0), (self.H, self.S, self.P))
+        self.Bv_broadcast = np.reshape(np.repeat(self.Bv, self.S, axis = 0), (self.H, self.S, self.P_ITA))
+        self.Bv_broadcast = np.pad(self.Bv_broadcast, ((0, 0), (0, self.S_ITA - self.S), (0, 0)))
 
         if self.bias:
             self.Bo_in = random_shuffled_tensor(
@@ -171,7 +174,8 @@ class Transformer:
         else:
             self.Bo_in = np.zeros((self.H, self.E), dtype = np.int8)
         self.Bo = np.pad(self.Bo_in, ((0, 0), (0, self.E_ITA - self.E)))
-        self.Bo_broadcast = np.reshape(np.repeat(self.Bo, self.S, axis = 0), (self.H, self.S, self.E))
+        self.Bo_broadcast = np.reshape(np.repeat(self.Bo, self.S, axis = 0), (self.H, self.S, self.E_ITA))
+        self.Bo_broadcast = np.pad(self.Bo_broadcast, ((0, 0), (0, self.S_ITA - self.S), (0, 0)))
 
         #### Intermediate tensors ####
 
@@ -287,7 +291,7 @@ class Transformer:
 
         # Bias Bqk is H x P
         # Broadcast Bias Bqk to H x S x P
-        bias = np.tile(bias, [1, self.S, 1])
+        bias = np.tile(bias, [1, self.S_ITA, 1])
         for h in range(self.H):
             Bias = split_matrix(bias[h], (self.ITA_M, self.ITA_N))
             write_matrix(Bias, f"{bias_file}_{h}", self.paths["standalone"])
@@ -330,7 +334,7 @@ class Transformer:
 
         # Bias Bv is H x P
         # Broadcast Bias Bv to H x S x P
-        bias = np.tile(bias, [1, self.S, 1])
+        bias = np.tile(bias, [1, self.S_ITA, 1])
         # Transpose Bias Bv to H x P x S
         bias = np.transpose(bias, (0, 2, 1))
         for h in range(self.H):
@@ -411,7 +415,7 @@ class Transformer:
 
         # Bias Bo is H x E
         # Broadcast Bias Bo to H x S x E
-        bias = np.tile(bias, [1, self.S, 1])
+        bias = np.tile(bias, [1, self.S_ITA, 1])
         for h in range(self.H):
             Bias = split_matrix(bias[h], (self.ITA_M, self.ITA_N))
             write_matrix(Bias, f"{bias_file}_{h}", self.paths["standalone"])
@@ -427,6 +431,12 @@ class Transformer:
         self.Qp_requant = requantize(self.Qp, self.requant_eps_mult[0], self.requant_right_shift[0],
                                      self.requant_add[0])
 
+        # Set padded values to zero
+        if (self.S_ITA - self.S) > 0:
+            self.Qp_requant[:, -(self.S_ITA - self.S):, :] = 0
+        if (self.P_ITA - self.P) > 0:
+            self.Qp_requant[:, :, -(self.P_ITA - self.P):] = 0
+
         self.tiler_QK(self.Q, self.Wq, self.Bq, self.Qp_requant, "Q", "Wq", "Bq", "Qp")
 
     def step2_Kp(self):
@@ -434,6 +444,11 @@ class Transformer:
         self.Kp = np.clip(self.Kp, -2**(self.WO - 1), 2**(self.WO - 1) - 1)
         self.Kp_requant = requantize(self.Kp, self.requant_eps_mult[1], self.requant_right_shift[1],
                                      self.requant_add[1])
+
+        if (self.S_ITA - self.S) > 0:
+            self.Kp_requant[:, -(self.S_ITA - self.S):, :] = 0
+        if (self.P_ITA - self.P) > 0:
+            self.Kp_requant[:, :, -(self.P_ITA - self.P):] = 0
 
         self.tiler_QK(self.K, self.Wk, self.Bk, self.Kp_requant, "K", "Wk", "Bk", "Kp")
 
@@ -443,6 +458,11 @@ class Transformer:
         self.Vp_requant = requantize(self.Vp, self.requant_eps_mult[2], self.requant_right_shift[2],
                                      self.requant_add[2])
 
+        if (self.S_ITA - self.S) > 0:
+            self.Vp_requant[:, -(self.S_ITA - self.S):, :] = 0
+        if (self.P_ITA - self.P) > 0:
+            self.Vp_requant[:, :, -(self.P_ITA - self.P):] = 0
+
         # Compute Vp in transposed form
         self.tiler_V(self.V, self.Wv, self.Bv, self.Vp_requant, "V", "Wv", "Bv", "Vp")
 
@@ -451,16 +471,27 @@ class Transformer:
             [np.matmul(self.Qp_requant[i], np.transpose(self.Kp_requant[i]), dtype = np.int32) for i in range(self.H)])
         self.A = np.clip(self.A, -2**(self.WO - 1), 2**(self.WO - 1) - 1)
         self.A_requant = requantize(self.A, self.requant_eps_mult[3], self.requant_right_shift[3], self.requant_add[3])
+
+        if (self.S_ITA - self.S) > 0:
+            self.A_requant[:, -(self.S_ITA - self.S):, :] = 0
+            self.A_requant[:, :, -(self.S_ITA - self.S):] = 0
+
         self.soft(no_partial_softmax)
 
         self.tiler_AV(self.Qp_requant, self.Kp_requant, self.A_requant, "Qp_in", "Kp_in", "A")
 
     def soft(self, no_partial_softmax = False):
-        self.A_real_softmax = realSoftmax(self.A_requant)
+        self.A_real_softmax = realSoftmax(self.A_requant[:, :self.S, :self.S])
+        self.A_real_softmax = np.pad(self.A_real_softmax, ((0, 0), (0, self.S_ITA - self.S), (0, self.S_ITA - self.S)))
+
         if no_partial_softmax:
-            self.A_partial_softmax = fastSoftmax(self.A_requant)
+            self.A_partial_softmax = fastSoftmax(self.A_requant[:, :self.S, :self.S])
+            self.A_partial_softmax = np.pad(self.A_partial_softmax,
+                                            ((0, 0), (0, self.S_ITA - self.S), (0, self.S_ITA - self.S)))
         else:
-            self.A_partial_softmax = streamingPartialSoftmax(self.A_requant)
+            self.A_partial_softmax = streamingPartialSoftmax(self.A_requant[:, :self.S, :self.S])
+            self.A_partial_softmax = np.pad(self.A_partial_softmax,
+                                            ((0, 0), (0, self.S_ITA - self.S), (0, self.S_ITA - self.S)))
 
         if self.H == 1:
             A_save = [np.tile(self.A_partial_softmax[i], [self.split, 1]) for i in range(self.H)]
@@ -476,6 +507,11 @@ class Transformer:
         self.O_soft_requant = requantize(self.O_soft, self.requant_eps_mult[4], self.requant_right_shift[4],
                                          self.requant_add[4])
 
+        if (self.S_ITA - self.S) > 0:
+            self.O_soft_requant[:, -(self.S_ITA - self.S):, :] = 0
+        if (self.P_ITA - self.P) > 0:
+            self.O_soft_requant[:, :, -(self.P_ITA - self.P):] = 0
+
         self.tiler_AV(self.A_requant, np.transpose(self.Vp_requant, (0, 2, 1)), self.O_soft_requant, "A_stream_soft_in",
                       "Vp_in", "O_soft")
 
@@ -484,6 +520,11 @@ class Transformer:
         self.Out_soft = np.clip(self.Out_soft, -2**(self.WO - 1), 2**(self.WO - 1) - 1)
         self.Out_soft_requant = requantize(self.Out_soft, self.requant_eps_mult[5], self.requant_right_shift[5],
                                            self.requant_add[5])
+
+        if (self.S_ITA - self.S) > 0:
+            self.Out_soft_requant[:, -(self.S_ITA - self.S):, :] = 0
+        if (self.E_ITA - self.E) > 0:
+            self.Out_soft_requant[:, :, -(self.E_ITA - self.E):] = 0
 
         self.tiler_Out(self.O_soft_requant, self.Wo, self.Bo, self.Out_soft_requant, "O_soft_in", "Wo", "Bo",
                        "Out_soft")
@@ -767,8 +808,8 @@ class Transformer:
 
     def export_numpy(self):
         assert np.all(np.equal(self.K, self.V)), "For ITA, keys and values have to be equal"
-        q = self.Q
-        k = self.K
+        q = self.Q_in
+        k = self.K_in
         w1 = self.Wq_in
         b1 = self.Bq_in
         w2 = self.Wk_in

--- a/PyITA/ITA_onnx.py
+++ b/PyITA/ITA_onnx.py
@@ -259,8 +259,8 @@ def exportONNX(path, verbose = False, **kwargs):
     # Transform from MUL-DIV-ADD to MUL-ADD-DIV
     RQ_ADD = (RQ_ADD * 2**RQ_SHIFT.astype(np.float32))
 
-    input0_values = np.expand_dims(inputs['q'][:(S * E // 64), :].reshape(S, E), axis = 0)
-    input1_values = np.expand_dims(inputs['k'][:(S * E // 64), :].reshape(S, E), axis = 0)
+    input0_values = np.expand_dims(inputs['q'].reshape(S, E), axis = 0)
+    input1_values = np.expand_dims(inputs['k'].reshape(S, E), axis = 0)
 
     np.savez(path + "inputs.npz", input0_values, input1_values)
 

--- a/PyITA/softmax.py
+++ b/PyITA/softmax.py
@@ -14,6 +14,8 @@
 #
 # ----------------------------------------------------------------------
 
+import argparse
+
 import numpy as np
 
 
@@ -71,10 +73,7 @@ def streamingPartialSoftmax(x, integerize = True):
 
     seq_length = x.shape[-1]
     n_heads = x.shape[-3]
-    width = 16  # 16 PE (processing units)
-    groups = seq_length // width
-
-    assert seq_length % width == 0, f"Sequence length must be a multiple of width ({width})"
+    PE = 16  # 16 PE (processing units)
 
     # Number of bits
     B = 8
@@ -101,12 +100,14 @@ def streamingPartialSoftmax(x, integerize = True):
         global_max = np.full((n_heads, seq_length), -np.Infinity, dtype = np.float32)
 
     ## STAGE 1: Compute the denominator of the softmax
-    for i in range(groups):
+    for i in range((seq_length + PE - 1) // PE):
+        width = seq_length % PE if i * PE + PE > seq_length else PE
+
         # Find the maximum for each row in the current column block (consisting of 16 columns)
         if integerize:
-            current_max = np.max(x[..., 0 + i * width:width + i * width].astype(np.int32), axis = -1)
+            current_max = np.max(x[..., 0 + i * PE:width + i * PE].astype(np.int32), axis = -1)
         else:
-            current_max = np.max(x[..., 0 + i * width:width + i * width].astype(np.float32), axis = -1)
+            current_max = np.max(x[..., 0 + i * PE:width + i * PE].astype(np.float32), axis = -1)
 
         # Initialize all shift values for each row to zero
         if integerize:
@@ -129,11 +130,11 @@ def streamingPartialSoftmax(x, integerize = True):
 
         # Find the difference between the maximum and x in the current part of the row
         if integerize:
-            diff = np.repeat(global_max, width).reshape(
-                n_heads, seq_length, width) - x[..., 0 + i * width:width + i * width].astype(np.int32)
+            diff = np.repeat(global_max, width).reshape(n_heads, seq_length,
+                                                        width) - x[..., 0 + i * PE:width + i * PE].astype(np.int32)
         else:
-            diff = np.repeat(global_max, width).reshape(
-                n_heads, seq_length, width) - x[..., 0 + i * width:width + i * width].astype(np.float32)
+            diff = np.repeat(global_max, width).reshape(n_heads, seq_length,
+                                                        width) - x[..., 0 + i * PE:width + i * PE].astype(np.float32)
 
         # Shift the values by B-log2B -> multiply by B/2**B = log2e*eps_x
         # Make sure to do use round-half-up instead of round-half-to-even
@@ -157,8 +158,6 @@ def streamingPartialSoftmax(x, integerize = True):
 
     ## STAGE 2: Calculate the softmax activation
     # Invert the partial sum
-    # WIESEP: Scale Softmax to 127
-    # The Softmax values are maximum 127 as sumdotp modules can only do signed-signed operations for now. This is a temporary fix until sumdotp is fixed.
     if integerize:
         exp_partial_sum_inverse = np.floor((2**8 - 1) * 2**8 / exp_partial_sum).astype(np.int32)
     else:
@@ -179,7 +178,7 @@ def streamingPartialSoftmax(x, integerize = True):
         # A_partial_softmax[0] = np.repeat(exp_partial_sum_inverse, seq_length).reshape(seq_length, seq_length) >> shift
         return np.floor(
             np.repeat(exp_partial_sum_inverse, seq_length).reshape(n_heads, seq_length, seq_length) / 2**shift).astype(
-                np.int8)
+                np.uint8)
     else:
         return np.repeat(exp_partial_sum_inverse, seq_length).reshape(n_heads, seq_length, seq_length) / 2**shift
 
@@ -197,7 +196,66 @@ def realSoftmax(A_requant, integerize = True):
         x = A_requant.astype(np.float64)
 
     exp = np.exp(x - np.max(x, axis = 2).reshape(n_heads, -1, 1))
+
+    # Replace nan with zero
+    exp = np.nan_to_num(exp)
+
     if integerize:
         return (exp / exp.sum(axis = 2).reshape(n_heads, -1, 1) * (2**7 - 1)).astype(A_requant.dtype)
     else:
         return exp / exp.sum(axis = 2).reshape(n_heads, -1, 1)
+
+
+if __name__ == "__main__":
+    np.set_printoptions(linewidth = 120)
+    np.set_printoptions(precision = 4)
+
+    # Always print whole array
+    np.set_printoptions(threshold = np.inf)
+
+    parser = argparse.ArgumentParser(description = "Test Utility for Softmax.")
+    # Sequence length
+    parser.add_argument("-S", default = 64, type = int, help = "Sequence length")
+
+    # ITA sequence length
+    parser.add_argument("-M", default = 64, type = int, help = "ITA sequence length")
+
+    # Quantiztion (float or int)
+    parser.add_argument("--int", action = "store_true", help = "Quantize to int")
+    parser.add_argument('--seed', default = 0, type = int, help = 'Random seed')
+
+    args = parser.parse_args()
+
+    ITA_WI = 8
+    WO = 26
+    ITA_N = 16
+    ITA_M = args.M
+
+    if args.seed != -1:
+        np.random.seed(args.seed)
+
+    if args.int:
+        x = np.random.randint(-128, 128, (1, 1, args.S, args.S)).astype(np.int8)
+    else:
+        x = np.random.randn(1, 1, 16, 16).astype(np.float32)
+
+    print("Input:")
+    print(x)
+
+    # Pad last two dimensions to be a multiple of ITA_M
+    pad_x = (ITA_M - x.shape[-1] % ITA_M) % ITA_M
+    pad_y = (ITA_M - x.shape[-2] % ITA_M) % ITA_M
+    pad_value = -2**(ITA_WI - 1) if args.int else -np.inf
+
+    print(f"Padding x by ({pad_y}, {pad_x}) with {pad_value}")
+    x_pad = np.pad(x, ((0, 0), (0, 0), (0, pad_y), (0, pad_x)), mode = 'constant', constant_values = pad_value)
+
+    res = realSoftmax(x, integerize = args.int)
+    res_pad = realSoftmax(x_pad, integerize = args.int)
+
+    res_unpad = res_pad[:, :, :args.S, :args.S]
+
+    # Compare results
+    print(f"Equal: {np.allclose(res, res_unpad, atol = 1e-3)}")
+    print(res)
+    print(res_unpad)

--- a/src/hwpe/ita_hwpe_ctrl.sv
+++ b/src/hwpe/ita_hwpe_ctrl.sv
@@ -65,6 +65,9 @@ module ita_hwpe_ctrl
     ctrl_engine_o.tile_s = reg_file.hwpe_params[ITA_REG_TILES][3:0];
     ctrl_engine_o.tile_e = reg_file.hwpe_params[ITA_REG_TILES][7:4];
     ctrl_engine_o.tile_p = reg_file.hwpe_params[ITA_REG_TILES][11:8];
+    ctrl_engine_o.seq_length = reg_file.hwpe_params[ITA_REG_LENGTH][7:0];
+    ctrl_engine_o.proj_space = reg_file.hwpe_params[ITA_REG_LENGTH][15:8];
+    ctrl_engine_o.embed_size = reg_file.hwpe_params[ITA_REG_LENGTH][23:16];
     ctrl_engine_o.eps_mult[0] = reg_file.hwpe_params[ITA_REG_EPS_MULT0][7:0];
     ctrl_engine_o.eps_mult[1] = reg_file.hwpe_params[ITA_REG_EPS_MULT0][15:8];
     ctrl_engine_o.eps_mult[2] = reg_file.hwpe_params[ITA_REG_EPS_MULT0][23:16];

--- a/src/hwpe/ita_hwpe_package.sv
+++ b/src/hwpe/ita_hwpe_package.sv
@@ -12,7 +12,7 @@ package ita_hwpe_package;
   parameter int unsigned N_CORES     = 9;
   parameter int unsigned N_CONTEXT   = 2;
   parameter int unsigned ID_WIDTH    = 2;
-  parameter int unsigned ITA_IO_REGS = 14; // 5 address + 8 parameters + 1 sync
+  parameter int unsigned ITA_IO_REGS = 15; // 5 address + 9 parameters + 1 sync
 
   parameter int unsigned ITA_TCDM_DW = 1024;
   parameter int unsigned ITA_INPUT_DW  = M*WI;
@@ -28,13 +28,14 @@ package ita_hwpe_package;
   parameter int unsigned ITA_REG_OUTPUT_PTR   =  4;
   parameter int unsigned ITA_REG_SEQ_LENGTH   =  5;
   parameter int unsigned ITA_REG_TILES        =  6; // tile_s [3:0], tile_e [7:4], tile_p [11:8]
-  parameter int unsigned ITA_REG_EPS_MULT0    =  7; // eps_mult[0] [7:0], eps_mult[1] [15:8], eps_mult[2] [23:16], eps_mult[3] [31:24]
-  parameter int unsigned ITA_REG_EPS_MULT1    =  8; // eps_mult[4] [7:0], eps_mult[5] [15:8]
-  parameter int unsigned ITA_REG_RIGHT_SHIFT0 =  9; // right_shift[0] [7:0], right_shift[1] [15:8], right_shift[2] [23:16], right_shift[3] [31:24]
-  parameter int unsigned ITA_REG_RIGHT_SHIFT1 = 10; // right_shift[4] [7:0], right_shift[5] [15:8]
-  parameter int unsigned ITA_REG_ADD0         = 11; // add[0] [7:0], add[1] [15:8], add[2] [23:16], add[3] [31:24]
-  parameter int unsigned ITA_REG_ADD1         = 12; // add[4] [7:0], add[5] [15:8]
-  parameter int unsigned ITA_REG_CTRL_STREAM  = 13; // ctrl_stream [0]: weight preload, ctrl_stream [1]: weight nextload, ctrl_stream [2]: bias disable, ctrl_stream [3]: bias direction, ctrl_stream [4]: output disable
+  parameter int unsigned ITA_REG_LENGTH       =  7; // tile_s [3:0], tile_e [7:4], tile_p [11:8]
+  parameter int unsigned ITA_REG_EPS_MULT0    =  8; // eps_mult[0] [7:0], eps_mult[1] [15:8], eps_mult[2] [23:16], eps_mult[3] [31:24]
+  parameter int unsigned ITA_REG_EPS_MULT1    =  9; // eps_mult[4] [7:0], eps_mult[5] [15:8]
+  parameter int unsigned ITA_REG_RIGHT_SHIFT0 = 10; // right_shift[0] [7:0], right_shift[1] [15:8], right_shift[2] [23:16], right_shift[3] [31:24]
+  parameter int unsigned ITA_REG_RIGHT_SHIFT1 = 11; // right_shift[4] [7:0], right_shift[5] [15:8]
+  parameter int unsigned ITA_REG_ADD0         = 12; // add[0] [7:0], add[1] [15:8], add[2] [23:16], add[3] [31:24]
+  parameter int unsigned ITA_REG_ADD1         = 13; // add[4] [7:0], add[5] [15:8]
+  parameter int unsigned ITA_REG_CTRL_STREAM  = 14; // ctrl_stream [0]: weight preload, ctrl_stream [1]: weight nextload, ctrl_stream [2]: bias disable, ctrl_stream [3]: bias direction, ctrl_stream [4]: output disable
 
   typedef struct packed {
     hci_package::hci_streamer_ctrl_t input_source_ctrl;

--- a/src/ita_controller.sv
+++ b/src/ita_controller.sv
@@ -10,24 +10,29 @@
 module ita_controller
   import ita_package::*;
 (
-  input  logic     clk_i                ,
-  input  logic     rst_ni               ,
-  input  ctrl_t    ctrl_i               ,
-  input  logic     inp_valid_i          ,
-  output logic     inp_ready_o          ,
-  input  logic     weight_valid_i       ,
-  output logic     weight_ready_o       ,
-  input  logic     bias_valid_i         ,
-  output logic     bias_ready_o         ,
-  input  logic     oup_valid_i          ,
-  input  logic     oup_ready_i          ,
-  input  logic     pop_softmax_fifo_i   ,
-  output step_e    step_o               ,
-  input  counter_t soft_addr_div_i      ,
-  input  logic     softmax_done_i       ,
-  output logic     calc_en_o            ,
-  output logic     first_inner_tile_o   ,
-  output logic     last_inner_tile_o    ,
+  input  logic         clk_i                ,
+  input  logic         rst_ni               ,
+  input  ctrl_t        ctrl_i               ,
+  input  logic         inp_valid_i          ,
+  output logic         inp_ready_o          ,
+  input  logic         weight_valid_i       ,
+  output logic         weight_ready_o       ,
+  input  logic         bias_valid_i         ,
+  output logic         bias_ready_o         ,
+  input  logic         oup_valid_i          ,
+  input  logic         oup_ready_i          ,
+  input  logic         pop_softmax_fifo_i   ,
+  output step_e        step_o               ,
+  input  counter_t     soft_addr_div_i      ,
+  input  logic         softmax_done_i       ,
+  output logic         calc_en_o            ,
+  output logic         first_inner_tile_o   ,
+  output logic         last_inner_tile_o    ,
+  output counter_t     tile_x_o             ,
+  output counter_t     tile_y_o             ,
+  output counter_t     inner_tile_o         ,
+  input  add_t         requant_add_i        ,
+  output requant_oup_t requant_add_o        ,
   output logic     busy_o
 );
 
@@ -35,19 +40,27 @@ module ita_controller
   counter_t count_d, count_q;
   counter_t tile_d, tile_q;
   counter_t inner_tile_d, inner_tile_q;
+  counter_t tile_x_d, tile_x_q;
+  counter_t tile_y_d, tile_y_q;
   counter_t softmax_tile_d, softmax_tile_q;
   ongoing_t ongoing_d, ongoing_q;
   ongoing_soft_t ongoing_soft_d, ongoing_soft_q;
 
   logic softmax_fifo, softmax_div, softmax_div_done_d, softmax_div_done_q, busy_d, busy_q;
+  requant_oup_t requant_add_d, requant_add_q;
 
   assign step_o    = step_q;
   assign busy_o    = busy_q;
+  assign tile_x_o  = tile_x_q;
+  assign tile_y_o  = tile_y_q;
+  assign inner_tile_o = inner_tile_q;
 
   always_comb begin
     count_d            = count_q;
     tile_d             = tile_q;
     inner_tile_d       = inner_tile_q;
+    tile_x_d           = tile_x_q;
+    tile_y_d           = tile_y_q;
     first_inner_tile_o = (inner_tile_q == 0) ? 1'b1 : 1'b0;
     last_inner_tile_o  = 1'b0;
     ongoing_d          = ongoing_q;
@@ -59,6 +72,8 @@ module ita_controller
     step_d             = step_q;
     softmax_tile_d     = softmax_tile_q;
     softmax_div_done_d = softmax_div_done_q;
+    requant_add_d      = {N {requant_add_i}};
+    requant_add_o      = requant_add_q;
 
     busy_d       = busy_q;
     softmax_fifo = 1'b0;
@@ -108,6 +123,8 @@ module ita_controller
     case (step_q)
       Idle : begin
         inner_tile_d = '0;
+        tile_x_d = '0;
+        tile_y_d = '0;
         tile_d = '0;
         softmax_tile_d = '0;
         softmax_div_done_d = 1'b0;
@@ -119,12 +136,33 @@ module ita_controller
       Q : begin
         if (inner_tile_q == ctrl_i.tile_e-1) begin
           last_inner_tile_o = 1'b1;
+          if ( ( ((count_q & (M-1)) + tile_y_q * M) > ( (ctrl_i.seq_length - 1) ) ) ) begin
+            requant_add_d = {N {1'b0}};
+          end else begin
+            if ( (count_q + tile_x_q * M*M/N) >= (ctrl_i.proj_space / N) * M ) begin
+              if ( ((count_q / M ) * N + tile_x_q * M ) < ctrl_i.proj_space) begin
+                for (int i = (ctrl_i.proj_space & (N-1)); i < N; i++) begin
+                  requant_add_d[i] = 1'b0;
+                end
+              end else begin
+                requant_add_d = {N {1'b0}};
+              end
+            end
+          end
         end
         if (inner_tile_d == ctrl_i.tile_e) begin // end of inner tile
           inner_tile_d = '0;
           tile_d = tile_q + 1;
+          if (tile_x_q == (ctrl_i.tile_p-1)) begin // end of step Q
+            tile_x_d = '0;
+            tile_y_d = tile_y_q + 1;
+          end else begin
+            tile_x_d = tile_x_q + 1;
+          end
           if (tile_d == ctrl_i.tile_s*ctrl_i.tile_p) begin // end of step Q
             tile_d = '0;
+            tile_x_d = '0;
+            tile_y_d = '0;
             step_d = K;
           end
         end
@@ -132,12 +170,33 @@ module ita_controller
       K: begin
         if (inner_tile_q == ctrl_i.tile_e-1) begin
           last_inner_tile_o = 1'b1;
+          if ( ( ((count_q & (M-1)) + tile_y_q * M) > ( (ctrl_i.seq_length - 1) ) ) ) begin
+              requant_add_d = {N {1'b0}};
+          end else begin
+            if ( (count_q + tile_x_q * M*M/N) >= (ctrl_i.proj_space / N) * M ) begin
+              if ( ((count_q / M ) * N + tile_x_q * M ) < ctrl_i.proj_space) begin
+                for (int i = (ctrl_i.proj_space & (N-1)); i < N; i++) begin
+                  requant_add_d[i] = 1'b0;
+                end
+              end else begin
+                requant_add_d = {N {1'b0}};
+              end
+            end
+          end
         end
         if (inner_tile_d == ctrl_i.tile_e) begin // end of inner tile
           inner_tile_d = '0;
           tile_d = tile_q + 1;
+          if (tile_x_q == (ctrl_i.tile_p-1)) begin // end of step Q
+            tile_x_d = '0;
+            tile_y_d = tile_y_q + 1;
+          end else begin
+            tile_x_d = tile_x_q + 1;
+          end
           if (tile_d == ctrl_i.tile_s*ctrl_i.tile_p) begin // end of step K
             tile_d = '0;
+            tile_x_d = '0;
+            tile_y_d = '0;
             step_d = V;
           end
         end
@@ -145,12 +204,33 @@ module ita_controller
       V: begin
         if (inner_tile_q == ctrl_i.tile_e-1) begin
           last_inner_tile_o = 1'b1;
+          if ( ( ((count_q & (M-1)) + tile_y_q * M) > ( (ctrl_i.proj_space - 1) ) ) ) begin
+              requant_add_d = {N {1'b0}};
+          end else begin
+            if ( (count_q + tile_x_q * M*M/N) >= (ctrl_i.seq_length / N) * M ) begin
+              if ( ((count_q / M ) * N + tile_x_q * M ) < ctrl_i.seq_length) begin
+                for (int i = (ctrl_i.seq_length & (N-1)); i < N; i++) begin
+                  requant_add_d[i] = 1'b0;
+                end
+              end else begin
+                requant_add_d = {N {1'b0}};
+              end
+            end
+          end
         end
         if (inner_tile_d == ctrl_i.tile_e) begin // end of inner tile
           inner_tile_d = '0;
           tile_d = tile_q + 1;
+          if (tile_x_q == (ctrl_i.tile_s-1)) begin // end of step Q
+            tile_x_d = '0;
+            tile_y_d = tile_y_q + 1;
+          end else begin
+            tile_x_d = tile_x_q + 1;
+          end
           if (tile_d == ctrl_i.tile_s*ctrl_i.tile_p) begin // end of step V
             tile_d = '0;
+            tile_x_d = '0;
+            tile_y_d = '0;
             step_d = QK;
           end
         end
@@ -158,10 +238,28 @@ module ita_controller
       QK : begin
         if (inner_tile_q == ctrl_i.tile_p-1) begin
           last_inner_tile_o = 1'b1;
+          if ( ( ((count_q & (M-1)) + tile_y_q * M) > ( (ctrl_i.seq_length - 1) ) ) ) begin
+              requant_add_d = {N {1'b0}};
+          end else begin
+            if ( (count_q + tile_x_q * M*M/N) >= (ctrl_i.seq_length / N) * M ) begin
+              if ( ((count_q / M ) * N + tile_x_q * M ) < ctrl_i.seq_length) begin
+                for (int i = (ctrl_i.seq_length & (N-1)); i < N; i++) begin
+                  requant_add_d[i] = 1'b0;
+                end
+              end else begin
+                requant_add_d = {N {1'b0}};
+              end
+            end
+          end
         end
         if (inner_tile_d == ctrl_i.tile_p) begin // end of inner tile
           inner_tile_d = '0;
           tile_d = tile_q + 1;
+          if (tile_x_q == (ctrl_i.tile_s-1)) begin // end of step Q
+            tile_x_d = '0;
+          end else begin
+            tile_x_d = tile_x_q + 1;
+          end
           if (tile_d == ctrl_i.tile_s) begin // end of step QK
             tile_d = '0;
             step_d = AV;
@@ -171,17 +269,38 @@ module ita_controller
       AV : begin
         if (inner_tile_q == ctrl_i.tile_s-1) begin
           last_inner_tile_o = 1'b1;
+          if ( ( ((count_q & (M-1)) + tile_y_q * M) > ( (ctrl_i.seq_length - 1) ) ) ) begin
+            requant_add_d = {N {1'b0}};
+          end else begin
+            if ( (count_q + tile_x_q * M*M/N) >= (ctrl_i.proj_space / N) * M ) begin
+              if ( ((count_q / M ) * N + tile_x_q * M ) < ctrl_i.proj_space) begin
+                for (int i = (ctrl_i.proj_space & (N-1)); i < N; i++) begin
+                  requant_add_d[i] = 1'b0;
+                end
+              end else begin
+                requant_add_d = {N {1'b0}};
+              end
+            end
+          end
         end
         if (inner_tile_d == ctrl_i.tile_s) begin // end of inner tile
           inner_tile_d = '0;
           tile_d = tile_q + 1;
+          if (tile_x_q == (ctrl_i.tile_p-1)) begin // end of step Q
+            tile_x_d = '0;
+          end else begin
+            tile_x_d = tile_x_q + 1;
+          end
           if (tile_d == ctrl_i.tile_p) begin
             tile_d = '0;
             softmax_tile_d = softmax_tile_q + 1;
             if (softmax_tile_d == ctrl_i.tile_s) begin
               softmax_tile_d = '0;
+              tile_x_d = '0;
+              tile_y_d = '0;
               step_d = OW;
             end else begin
+              tile_y_d = tile_y_q + 1;
               step_d = QK;
             end
           end
@@ -190,12 +309,33 @@ module ita_controller
       OW : begin
         if (inner_tile_q == ctrl_i.tile_p-1) begin
           last_inner_tile_o = 1'b1;
+          if ( ( ((count_q & (M-1)) + tile_y_q * M) > ( (ctrl_i.seq_length - 1) ) ) ) begin
+            requant_add_d = {N {1'b0}};
+          end else begin
+            if ( (count_q + tile_x_q * M*M/N) >= (ctrl_i.embed_size / N) * M ) begin
+              if ( ((count_q / M ) * N + tile_x_q * M ) < ctrl_i.embed_size) begin
+                for (int i = (ctrl_i.embed_size & (N-1)); i < N; i++) begin
+                  requant_add_d[i] = 1'b0;
+                end
+              end else begin
+                requant_add_d = {N {1'b0}};
+              end
+            end
+          end
         end
         if (inner_tile_d == ctrl_i.tile_p) begin // end of inner tile
           inner_tile_d = '0;
           tile_d = tile_q + 1;
+          if (tile_x_q == (ctrl_i.tile_e-1)) begin // end of step Q
+            tile_x_d = '0;
+            tile_y_d = tile_y_q + 1;
+          end else begin
+            tile_x_d = tile_x_q + 1;
+          end
           if (tile_d == ctrl_i.tile_s*ctrl_i.tile_e) begin // end of step OW
             tile_d = '0;
+            tile_x_d = '0;
+            tile_y_d = '0;
             step_d = Idle;
           end
         end
@@ -227,16 +367,20 @@ module ita_controller
       ongoing_q <= '0;
       ongoing_soft_q <= '0;
       softmax_div_done_q <= 1'b0;
+      requant_add_q <= '0;
       busy_q <= 1'b0;
     end else begin
       step_q    <= step_d;
       count_q   <= count_d;
       tile_q    <= tile_d;
+      tile_x_q  <= tile_x_d;
+      tile_y_q  <= tile_y_d;
       inner_tile_q <= inner_tile_d;
       softmax_tile_q <= softmax_tile_d;
       ongoing_q <= ongoing_d;
       ongoing_soft_q <= ongoing_soft_d;
       softmax_div_done_q <= softmax_div_done_d;
+      requant_add_q <= requant_add_d;
       busy_q <= busy_d;
     end
   end

--- a/src/ita_package.sv
+++ b/src/ita_package.sv
@@ -29,9 +29,9 @@ package ita_package;
   parameter  int unsigned N_WRITE_EN     = `ifdef TARGET_ITA_HWPE 8 `else M `endif;
 
   // IO
-  typedef logic [idx_width(S+1)-1:0] seq_length_t;
-  typedef logic [idx_width(P+1)-1:0] proj_space_t;
-  typedef logic [idx_width(E+1)-1:0] embed_size_t;
+  typedef logic [WO-WI*2-2:0] seq_length_t;
+  typedef logic [WO-WI*2-2:0] proj_space_t;
+  typedef logic [WO-WI*2-2:0] embed_size_t;
   typedef logic [idx_width(H+1)-1:0] n_heads_t;
   typedef logic [           EMS-1:0] eps_mult_t;
   typedef logic [           EMS-1:0] right_shift_t;

--- a/src/ita_requantizer.sv
+++ b/src/ita_requantizer.sv
@@ -22,7 +22,8 @@ module ita_requantizer
   logic signed [EMS+WO:0]               product      ;
   logic signed [EMS+WO:0]               shifted_added;
   logic signed [     N-1:0][EMS+WO-1:0] shifted_d, shifted_q;
-  requant_oup_t                         add_q1, requant_oup_d, requant_oup_q;
+  requant_oup_t                         add_q1, add_q2, add_q3, add_q4;
+  requant_oup_t                         requant_oup_d, requant_oup_q;
 
   assign requant_oup_o   = requant_oup_q;
 
@@ -49,7 +50,7 @@ module ita_requantizer
         end
       end
       if (calc_en_q_i) begin
-        shifted_added    = shifted_q[i] + (EMS+WO)'(signed'(add_q1[i]));
+        shifted_added    = shifted_q[i] + (EMS+WO)'(signed'(add_q4[i]));
         requant_oup_d[i] = shifted_added[WI-1:0];
         if (~shifted_added[EMS+WO-1] & (|(shifted_added[EMS+WO-2:WI-1]))) begin
           requant_oup_d[i]       = '1;
@@ -76,8 +77,14 @@ module ita_requantizer
   always_ff @(posedge clk_i, negedge rst_ni) begin
     if (!rst_ni) begin
       add_q1         <= '0;
+      add_q2         <= '0;
+      add_q3         <= '0;
+      add_q4         <= '0;
     end else begin
       add_q1         <= add_i;
+      add_q2         <= add_q1;
+      add_q3         <= add_q2;
+      add_q4         <= add_q3;
     end
   end
 endmodule

--- a/src/ita_softmax.sv
+++ b/src/ita_softmax.sv
@@ -39,14 +39,19 @@ module ita_softmax
   input  requant_t [1:0]                      read_max_data_i,
   output logic                                write_max_en_o,
   output logic [InputAddrWidth-1:0]           write_max_addr_o,
-  output requant_t                            write_max_data_o    
+  output requant_t                            write_max_data_o,
+  input  counter_t                            tile_x_i,
+  input  counter_t                            tile_y_i,
+  input  counter_t                            inner_tile_i
 );
 
   counter_t tile_d, tile_q1, tile_q2, tile_q3, tile_q4;
   counter_t count_d, count_q1, count_q2, count_q3, count_q4;
+  counter_t inner_tile_q;
+  counter_t tile_y_q;
 
   logic unsigned [SoftmaxAccDataWidth-1:0] exp_sum_d, exp_sum_q;
-  counter_t count_soft_d, count_soft_q;
+  counter_t count_soft_d, count_soft_q1, count_soft_q2;
 
   counter_t count_div_d, count_div_q, addr_div_d, addr_div_q;
   logic [NumDiv-1:0] div_read_d, div_read_q, div_write_d, div_write_q;
@@ -69,13 +74,19 @@ module ita_softmax
   logic [SoftmaxAccDataWidth-1:0]  data_to_fifo, data_from_fifo;
   soft_fifo_usage_t fifo_usage  ;
 
+  logic [N-1:0] disable_shift;
+  logic disable_row;
+  logic [M-1:0]disable_col;
+
+  assign disable_row = ((count_soft_q2 & (M-1)) + tile_y_q * M) > (ctrl_i.seq_length - 1);
+
   assign pop_softmax_fifo_o = pop_from_fifo;
   assign soft_addr_div_o    = addr_div_q;
 
   always_comb begin
     tile_d            = tile_q1;
     count_d           = count_q1;
-    count_soft_d      = count_soft_q;
+    count_soft_d      = count_soft_q1;
     count_div_d       = count_div_q;
     div_read_d        = div_read_q;
     div_write_d       = div_write_q;
@@ -135,13 +146,20 @@ module ita_softmax
 
     //************ Pipeline Stage 1 ************//
     if (calc_en_q1) begin // Find max and accumulate
-      max_o = requant_oup_q;
       max_d = max_i;
       for (int i = 0; i < N; i++) begin
         shift_diff[i] = max_i - requant_oup_q[i];
-        shift_d[i]    = unsigned'(shift_diff[i]) >> 5;
-        if (shift_diff[i][4])
-          shift_d[i] = (unsigned'(shift_diff[i]) >> 5) + 1;
+        disable_shift[i] = ( (tile_q2*M+N*(count_q2 >> $clog2(M))+i ) >= ctrl_i.seq_length);
+
+        if (disable_shift[i]) begin
+          max_o[i] = 8'h80;
+          shift_d[i] = 4'hF;
+        end else begin
+          max_o[i] = requant_oup_q[i];
+          shift_d[i]    = unsigned'(shift_diff[i]) >> 5;
+          if (shift_diff[i][4])
+            shift_d[i] = (unsigned'(shift_diff[i]) >> 5) + 1;
+        end
       end
       if (tile_q2 != '0 || count_q2>=M) begin // If not first part of the first row, normalize previous sum
         read_acc_en_o[0]   = 1;
@@ -162,7 +180,8 @@ module ita_softmax
       write_max_addr_o = count_q3;
       write_max_data_o = max_q;
       for (int i = 0; i < N; i++) begin
-        exp_sum_d += unsigned'(9'h100)>>shift_q[i];
+        if (shift_d[i] != 4'hF)
+          exp_sum_d += unsigned'(9'h100)>>shift_q[i];
       end
       if (tile_q3 != '0 || count_q3>=M) begin // If not first part of the first row
         exp_sum_d += ( unsigned'(read_acc_data_i[0]) >> shift_sum_q);
@@ -211,28 +230,39 @@ module ita_softmax
     //*********** Stream Softmax ***********//
     // Main controller checks if division is ready
     if (calc_stream_soft_en_i) begin
-      count_soft_d    = count_soft_q + 1;
+      count_soft_d    = count_soft_q1 + 1;
       read_acc_en_o[1]   = 1;
-      read_acc_addr_o[1] = count_soft_q[5:0];
+      read_acc_addr_o[1] = count_soft_q1[5:0];
       read_max_en_o[1]   = 1;
-      read_max_addr_o[1] = count_soft_q[5:0];
+      read_max_addr_o[1] = count_soft_q1[5:0];
       if (count_soft_d == M*M/N) begin
         count_soft_d = '0;
       end
     end
     if (calc_stream_soft_en_q) begin
-      for (int i = 0; i < M; i++) begin
-        shift_inp_diff[i] = read_max_data_i[1]-inp_i[i];
-        shift_inp[i]      = unsigned'(shift_inp_diff[i]) >> 5;
-        if (shift_inp_diff[i][4])
-          shift_inp[i] = (unsigned'(shift_inp_diff[i]) >> 5) + 1;
-        inp_stream_soft_o[i] = read_acc_data_i[1] >> shift_inp[i];
+      if (disable_row) begin
+        inp_stream_soft_o = { M { '0 } };
+      end else begin
+        for (int i = 0; i < M; i++) begin
+          disable_col[i] = ((inner_tile_q*M + i) >= ctrl_i.seq_length);
+          if (disable_col[i]) begin
+            inp_stream_soft_o[i] = '0;
+          end else begin
+            shift_inp_diff[i] = read_max_data_i[1]-inp_i[i];
+            shift_inp[i]      = unsigned'(shift_inp_diff[i]) >> 5;
+            if (shift_inp_diff[i][4])
+              shift_inp[i] = (unsigned'(shift_inp_diff[i]) >> 5) + 1;
+            inp_stream_soft_o[i] = read_acc_data_i[1] >> shift_inp[i];
+          end
+        end
       end
     end
   end
 
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if(~rst_ni) begin
+      inner_tile_q          <= '0;
+      tile_y_q              <= '0;
       tile_q4               <= '0;
       tile_q3               <= '0;
       tile_q2               <= '0;
@@ -240,8 +270,9 @@ module ita_softmax
       count_q4              <= M*M/N;
       count_q3              <= M*M/N;
       count_q2              <= M*M/N;
-      count_q1               <= M*M/N;
-      count_soft_q          <= '0;
+      count_q1              <= M*M/N;
+      count_soft_q1         <= '0;
+      count_soft_q2         <= '0;
       count_div_q           <= '0;
       div_read_q            <= '0;
       div_write_q           <= '0;
@@ -253,6 +284,8 @@ module ita_softmax
       shift_q               <= '0;
       shift_sum_q           <= '0;
     end else begin
+      inner_tile_q          <= inner_tile_i;
+      tile_y_q              <= tile_y_i;
       tile_q4               <= tile_q3;
       tile_q3               <= tile_q2;
       tile_q2               <= tile_q1;
@@ -261,7 +294,8 @@ module ita_softmax
       count_q3              <= count_q2;
       count_q2              <= count_q1;
       count_q1              <= count_d;
-      count_soft_q          <= count_soft_d;
+      count_soft_q1          <= count_soft_d;
+      count_soft_q2          <= count_soft_q1;
       count_div_q           <= count_div_d;
       div_read_q            <= div_read_d;
       div_write_q           <= div_write_d;
@@ -307,5 +341,5 @@ module ita_softmax
     .data_o    (data_from_fifo),
     .pop_i     (pop_from_fifo )
   );
-  
+
 endmodule : ita_softmax

--- a/src/ita_softmax_top.sv
+++ b/src/ita_softmax_top.sv
@@ -19,7 +19,11 @@ module ita_softmax_top
   output counter_t     soft_addr_div_o      ,
   output logic         softmax_done_o       ,
   output logic         pop_softmax_fifo_o   ,
-  output inp_t         inp_stream_soft_o
+  output inp_t         inp_stream_soft_o    ,
+  input  counter_t     tile_x_i             ,
+  input  counter_t     tile_y_i             ,
+  input  counter_t     inner_tile_i
+
 );
 
   logic          [1:0]                                       read_acc_en;
@@ -113,7 +117,11 @@ module ita_softmax_top
 
     .write_max_en_o       (write_max_en         ),
     .write_max_addr_o     (write_max_addr       ),
-    .write_max_data_o     (write_max_data       )
+    .write_max_data_o     (write_max_data       ),
+
+    .tile_x_i             (tile_x_i             ),
+    .tile_y_i             (tile_y_i             ),
+    .inner_tile_i         (inner_tile_i          )
   );
 
   ita_register_file_1w_multi_port_read #(


### PR DESCRIPTION
This PR introduces initial support for handling arbitrary matrix shapes by adjusting both the Python model and the softmax hardware module. 

## Changes
Python Model:
- Modified to golden model for arbitrary shapes by padding the inputs with zeros as needed.
- Updated to selectively ignore padded input values during the softmax operation

## Current Limitations
- Non-zero biases are not yet supported
- The HWPE version does not yet work correctly. There is most likely a bug
