### PR TITLE
Improve Test Vector Generation

### DIFF
--- a/PyITA/ITA.py
+++ b/PyITA/ITA.py
@@ -259,7 +259,7 @@ class Transformer:
             elif i == 3:  # QK
                 max_bit_width = np.log2(self.requant_eps_mult[i, :].astype(np.uint32) * self.P * 2**8).astype(np.uint32)
             elif i == 4:  # AV
-                max_bit_width = np.log2(self.requant_eps_mult[i, :].astype(np.uint32) * self.S * 2**8).astype(np.uint32)
+                max_bit_width = np.log2(self.requant_eps_mult[i, :].astype(np.uint32) * self.S * 2**5).astype(np.uint32)
             elif i == 5:  # OW
                 max_bit_width = np.log2(self.requant_eps_mult[i, :].astype(np.uint32) * self.E * 2**9).astype(np.uint32)
             elif i == 6:  # Sum OW

--- a/PyITA/ITA.py
+++ b/PyITA/ITA.py
@@ -133,35 +133,35 @@ class Transformer:
 
         self.exp_sum = np.zeros(self.S, dtype = np.int32)
 
-        self.Q_in = random_shuffled_tensor((self.S, self.E), self.WI - 1) if Q is None else Q
+        self.Q_in = random_shuffled_tensor((self.S, self.E), self.WI) if Q is None else Q
         self.Q = np.pad(self.Q_in, ((0, self.S_ITA - self.S), (0, self.E_ITA - self.E)))
 
-        self.V_in = random_shuffled_tensor((self.S, self.E), self.WI - 1) if V is None else V
+        self.V_in = random_shuffled_tensor((self.S, self.E), self.WI) if V is None else V
         self.V = np.pad(self.V_in, ((0, self.S_ITA - self.S), (0, self.E_ITA - self.E)))
 
         # WIESEP: K is the same as V because we do cross-attention
         self.K_in = self.V_in
         self.K = self.V
 
-        self.FF_in = random_shuffled_tensor((self.S, self.E), self.WI - 1) if FF_in is None else FF_in
+        self.FF_in = random_shuffled_tensor((self.S, self.E), self.WI) if FF_in is None else FF_in
         self.FF = np.pad(self.FF_in, ((0, self.S_ITA - self.S), (0, self.E_ITA - self.E)))
 
         #### Weight matrices ####
-        self.Wq_in = random_shuffled_tensor((self.H, self.E, self.P), self.WI - 1) if Wq is None else Wq
+        self.Wq_in = random_shuffled_tensor((self.H, self.E, self.P), self.WI) if Wq is None else Wq
         self.Wq = np.pad(self.Wq_in, ((0, 0), (0, self.E_ITA - self.E), (0, self.P_ITA - self.P)))
 
-        self.Wk_in = random_shuffled_tensor((self.H, self.E, self.P), self.WI - 1) if Wk is None else Wk
+        self.Wk_in = random_shuffled_tensor((self.H, self.E, self.P), self.WI) if Wk is None else Wk
         self.Wk = np.pad(self.Wk_in, ((0, 0), (0, self.E_ITA - self.E), (0, self.P_ITA - self.P)))
 
-        self.Wv_in = random_shuffled_tensor((self.H, self.E, self.P), self.WI - 1) if Wv is None else Wv
+        self.Wv_in = random_shuffled_tensor((self.H, self.E, self.P), self.WI) if Wv is None else Wv
         self.Wv = np.pad(self.Wv_in, ((0, 0), (0, self.E_ITA - self.E), (0, self.P_ITA - self.P)))
 
-        self.Wo_in = random_shuffled_tensor((self.H, self.P, self.E), self.WI - 1) if Wo is None else Wo
+        self.Wo_in = random_shuffled_tensor((self.H, self.P, self.E), self.WI) if Wo is None else Wo
         self.Wo = np.pad(self.Wo_in, ((0, 0), (0, self.P_ITA - self.P), (0, self.E_ITA - self.E)))
 
-        self.Wff_in = random_shuffled_tensor((1, self.E, self.F), self.WI - 1) if Wff is None else Wff
+        self.Wff_in = random_shuffled_tensor((1, self.E, self.F), self.WI) if Wff is None else Wff
         self.Wff = np.pad(self.Wff_in, ((0, 0), (0, self.E_ITA - self.E), (0, self.F_ITA - self.F)))
-        self.Wff2_in = random_shuffled_tensor((1, self.F, self.E), self.WI - 1) if Wff2 is None else Wff2
+        self.Wff2_in = random_shuffled_tensor((1, self.F, self.E), self.WI) if Wff2 is None else Wff2
         self.Wff2 = np.pad(self.Wff2_in, ((0, 0), (0, self.F_ITA - self.F), (0, self.E_ITA - self.E)))
 
         #### Bias matrices ####

--- a/PyITA/util.py
+++ b/PyITA/util.py
@@ -517,3 +517,21 @@ def almost_symmetric_dequantize(quantized_activations: np.ndarray, clip_lo: f32,
     S, _ = get_almost_symmetric_scaling_factor(clip_lo, n_bits)
     activations = quantized_activations * S
     return activations
+
+
+def error_MAEP(a: np.ndarray, b: np.ndarray):
+    """
+    Compute the mean absolute error percentage (MAEP) between two tensors.
+    A value of 0 indicates that the two tensors are equal.
+    A value of 100 indicates that the second tensor is on average twice as large as the first tensor.
+
+    Parameters:
+        a (np.ndarray): The first tensor.
+        b (np.ndarray): The second tensor.
+
+    Returns:
+        np.ndarray: The mean absolute error percentage between the two tensors.
+    """
+    return 100 * np.mean(np.abs(a - b)) / max(
+        np.abs(np.max(a)) + np.abs(np.min(a)),
+        np.abs(np.max(b)) + np.abs(np.min(b)))


### PR DESCRIPTION
This PR improves the test vector generation and ensure that we have non-constant output vectors. Furthermore, it fixes the too small bit width of the weights.

## Added
- Print and raise warnings for problematic vectors
- Print and check the error of the partial streaming softmax relative to the integer softmax

## Changed
- Reduce calculated bit width of AV (This assumes that the attention is distributed among different values and not on one token)

## Fixed
- Fix wrong bitwidth of weights (the -1 is already handled in the `random_shuffled_tensor` function)